### PR TITLE
Fixed error-producing Makefile; Also does a better cleanup job.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ box2d.clean.h:
 	cpp -x c++ -DEM_NO_LIBCPP -IBox2D_v2.2.1 root.h > box2d.clean.h
 
 box2d_bindings.cpp: box2d.clean.h
-	$(PYTHON) $(EMSCRIPTEN)/tools/bindings_generator.py box2d_bindings box2d.clean.h -- '{ "ignored": "b2Shape::m_type,b2BroadPhase::RayCast,b2BroadPhase::UpdatePairs,b2BroadPhase::Query,b2DynamicTree::RayCast,b2DynamicTree::Query,b2ChainShape::m_nextVertex,b2ChainShape::m_hasNextVertex,b2EdgeShape::m_hasVertex3,b2EdgeShape::m_vertex2,b2EdgeShape::m_vertex3,b2Mat22,b2Mat33" }' > bindings.out
+	$(PYTHON) ../emscripten/tools/bindings_generator.py box2d_bindings box2d.clean.h -- '{ "ignored": "b2Shape::m_type,b2BroadPhase::RayCast,b2BroadPhase::UpdatePairs,b2BroadPhase::Query,b2DynamicTree::RayCast,b2DynamicTree::Query,b2ChainShape::m_nextVertex,b2ChainShape::m_hasNextVertex,b2EdgeShape::m_hasVertex3,b2EdgeShape::m_vertex2,b2EdgeShape::m_vertex3,b2Mat22,b2Mat33" }' > bindings.out
 
 box2d_bindings.bc: box2d_bindings.cpp
 	$(CXX) -IBox2D_v2.2.1 -include root.h $< -o $@


### PR DESCRIPTION
The error message that the Makefile produces and which this pull corrects:

```
python: can't open file '1/tools/bindings_generator.py': [Errno 2] No such file or directory
```
