### PR TITLE
Remove link to scam site from README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -52,8 +52,6 @@ R.U.B.E testbed
 
 The demo/rube_testbed folder contains the testbed with scenes which were exported from the R.U.B.E editor
 
-**Demo: http://argadnet.com/demo/rube_testbed/box2djs/index.php**
-
 Building
 --------
 


### PR DESCRIPTION
Seems like the domain has been hijacked and now redirects to a scam site.

```
$ curl -I http://argadnet.com/demo/rube_testbed/box2djs/index.php

HTTP/1.1 302 Found
server: nginx
date: Fri, 09 Jun 2017 14:10:25 GMT
content-length: 11
set-cookie: sid=621acd58-4d1d-11e7-8f08-25d81a003d98; path=/; domain=argadnet.com; HttpOnly
cache-control: max-age=0, private, must-revalidate
location: http://survey-winner.com
```

It in turn redirected me to a scam website that displayed a quite real scam site featuring my ISP name and brand colors.
![screen shot 2017-06-09 at 17 09 36](https://user-images.githubusercontent.com/482561/26979425-6054063c-4d37-11e7-9fb7-a41ac7151f26.png)

