### PR TITLE
No need for c++ exceptions or rtti (15% smaller) and allow growth in wasm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(ACTIVE)/Box2D/Rope/b2Rope.bc
 all: box2d.js box2d.wasm.js
 
 %.bc: %.cpp
-	$(CXX) $(OPTS) -I$(ACTIVE) $< -o $@
+	$(CXX) $(OPTS) -I$(ACTIVE) $< -o $@ -fno-exceptions -fno-rtti
 
 box2d.bc: $(OBJECTS)
 	$(CXX) $(OPTS) -I$(ACTIVE) -o $@ $(OBJECTS)
@@ -98,7 +98,7 @@ box2d.js: box2d.bc box2d_glue.cpp box2d_glue.h
 	$(CXX) $(LINK_OPTS) -I$(ACTIVE) $< -o build/$(ACTIVE)_$(BUILD).js
 
 box2d.wasm.js: box2d.bc box2d_glue.cpp box2d_glue.h
-	$(CXX) $(LINK_OPTS) -I$(ACTIVE) $< -o build/$(ACTIVE)_$(BUILD).wasm.js -s WASM=1
+	$(CXX) $(LINK_OPTS) -I$(ACTIVE) $< -o build/$(ACTIVE)_$(BUILD).wasm.js -s WASM=1 -s ALLOW_MEMORY_GROWTH=1
 
 clean:
 	rm -f $(OBJECTS)


### PR DESCRIPTION
Some improvements we should add, first to shrink the size by disabling c++ features we don't need, and second to enable growth in wasm where it has almost no overhead and is useful in allowing arbitrary size data usage.

I'm not able to build box2d currently, though, due to errors like
```
In file included from glue_stub.cpp:27:
./box2d_glue.cpp:1124:10: error: no viable overloaded '+='
  (*self += arg0);
   ~~~~~ ^  ~~~~
Box2D_v2.2.1/Box2D/Common/b2Math.h:94:7: note: candidate function not viable: no known conversion from 'const b2Vec2 *' to 'const b2Vec2' for
      1st argument; dereference the argument with *
        void operator += (const b2Vec2& v)
             ^
```
Perhaps we introduced a bug in the idl file? Or maybe an emscripten update broke things? If no one has an answer, we should go back in the history in the two repos to when things worked and bisect to see what went wrong.